### PR TITLE
Adicionada fase de aquecimento

### DIFF
--- a/src/main/java/com/edgardleal/benchmark/Benchmark.java
+++ b/src/main/java/com/edgardleal/benchmark/Benchmark.java
@@ -28,6 +28,7 @@ public class Benchmark {
 
   public static Benchmark benchmarkForRunnable(Runnable runnable, String name) {
     Benchmark benchmark = new Benchmark(runnable, name);
+    benchmark.start(150); // warmup
     benchmark.start(150);
     System.out.printf("+----------------------------------------------+\n| %-45s|\n", name);
     benchmark.printStatistics();


### PR DESCRIPTION
Benchmarks precisam de uma etapa de aquecimento para que o algoritmo esteja em cache e a memória necessária já esteja alocada.